### PR TITLE
Fix typo in vertical centering snippet: s/align-content/align-items/

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -497,7 +497,7 @@ var flexbox;
                         "action": null
                     },
                     {
-                        "text": 'One of the most useful right out-of-the-box is vertical centering. Clear your screen of flex items and add just one. Make sure "justify-content" and "align-content" have been set to "center".',
+                        "text": 'One of the most useful right out-of-the-box is vertical centering. Clear your screen of flex items and add just one. Make sure "justify-content" and "align-items" have been set to "center".',
                         "hasButton": false,
                         "xUrl": null,
                         "xText": null,


### PR DESCRIPTION
The snippet on vertical centering a single item currently says:

> Make sure "justify-content" and "align-content" have been set to "center"

It means to say "align-items" instead of "align-content". (align-content has no effect until there are multiple rows, as noted in an earlier slide)
