### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 =======
-##flexbox in 5 minutes
+## flexbox in 5 minutes
 
-###an interactive tour of all the major features of the new CSS property: flexbox.
+### an interactive tour of all the major features of the new CSS property: flexbox.
 
 What can you do here?
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
